### PR TITLE
Add basic (temporary) analytics

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,8 +9,9 @@
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
 
     <script async defer
-      data-website-id="b3703dbf-d8a9-4a47-aa4b-f3965c3b0ecf"
+      data-website-id="94658381-1e2d-40a1-ac42-62e3e00cc7da"
       data-do-not-track="true"
+      data-auto-track="false"
       src="https://132e7f8f0abb.ngrok.io/umami.js"
     ></script>
 

--- a/public/index.html
+++ b/public/index.html
@@ -1,11 +1,21 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
+
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
+
+    <script async defer
+      data-website-id="b3703dbf-d8a9-4a47-aa4b-f3965c3b0ecf"
+      data-do-not-track="true"
+      src="https://132e7f8f0abb.ngrok.io/umami.js"
+    ></script>
+
     <title>ODCrawler</title>
+
   </head>
   <body
     class="min-h-full dark bg-gray-100 dark:bg-gray-900"

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -206,6 +206,8 @@ export default {
   },
   mounted() {
 
+    window.umami.trackView(`/`);
+
   },
 }
 </script>

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -223,6 +223,8 @@ export default {
         level: `normal`,
       }
 
+      window.umami(`loadNextPage`);
+
       try {
 
         this.loadingResults = true;
@@ -288,6 +290,8 @@ export default {
     }, 7000);
 
     window.addEventListener(`orientationchange`, this.handleOrientationChange);
+
+    window.umami.trackView(`/search`);
 
   },
   beforeDestroy() {


### PR DESCRIPTION
This will only work for a couple hours.

What is tracked:
- \# of visits to beta.odcrawler.xyz
- \# of visits to beta.odcrawler.xyz/search (**without** the search query!)
- \# of times the next page is loaded (or at least attempted to load) via infinite scroll